### PR TITLE
3 add build target for opa machine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,3 +45,12 @@ validate-jupyterhub: check-region init jupyterhub.pkrvars.hcl
 .PHONY: build-jupyterhub
 build-jupyterhub: check-region init validate release.auto.pkrvars.hcl jupyterhub.pkrvars.hcl
 	packer build -only="amazon-ebs.al2023" -var "region=${REGION}" --var-file="jupyterhub.pkrvars.hcl" .
+
+
+.PHONY: validate-opa
+validate-opa: check-region init opa.pkrvars.hcl
+	packer validate -var "region=${REGION}" --var-file="opa.pkrvars.hcl" .
+
+.PHONY: build-opa
+build-opa: check-region init validate release.auto.pkrvars.hcl opa.pkrvars.hcl
+	packer build -only="amazon-ebs.al2023" -var "region=${REGION}" --var-file="opa.pkrvars.hcl" .

--- a/opa.pkrvars.hcl
+++ b/opa.pkrvars.hcl
@@ -1,0 +1,2 @@
+ami_name_prefix     = "opa"
+

--- a/scripts/additional-scripts/opa/01-install-opa.sh
+++ b/scripts/additional-scripts/opa/01-install-opa.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -ex
+
+AMI_SCRIPTS=/tmp/additional-scripts/"${AMI_PREFIX}"
+
+OPA_VERSION=v1.4.2
+LOCAL_BIN=/usr/local/bin
+OPA_ETC_PATH=/etc/opa
+
+sudo curl -L -o ${LOCAL_BIN}/opa https://github.com/open-policy-agent/opa/releases/download/${OPA_VERSION}/opa_linux_amd64
+sudo chmod 755 ${LOCAL_BIN}/opa
+
+# TODO: get the service file and config correct
+
+# copy default OPA config
+sudo mkdir -p "${OPA_ETC_PATH}/config"
+sudo cp "${AMI_SCRIPTS}"/opa-config.yaml "${OPA_ETC_PATH}"/config/opa-config.yaml
+
+# copy opa service file
+sudo mkdir -p "${OPA_ETC_PATH}/systemd"
+sudo cp "${AMI_SCRIPTS}"/opa.service "${OPA_ETC_PATH}"/systemd/opa.service
+sudo ln -s "${OPA_ETC_PATH}"/systemd/opa.service /etc/systemd/system/opa.service
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now opa.service
+sudo systemctl start opa.service

--- a/scripts/additional-scripts/opa/opa-config.yaml
+++ b/scripts/additional-scripts/opa/opa-config.yaml
@@ -1,0 +1,9 @@
+# by default we have no services, bundles, decision_logs, or statii. all of 
+# this will come from the configuration that will be given to the instance 
+# when it is spun up for a specific task
+labels:
+  app: cape-opa-default-config
+  region: east
+  environment: dev
+
+default_decision: deny

--- a/scripts/additional-scripts/opa/opa.service
+++ b/scripts/additional-scripts/opa/opa.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=CAPE Open Policy Agent
+After=network.target
+StartLimitInterval=60
+StartLimitBurst=4
+
+[Service]
+ExecStart=/usr/local/bin/opa run --server --addr=0.0.0.0:8181 --config-file=/etc/opa/config/opa-config.yaml
+
+RuntimeDirectory=opa
+WorkingDirectory=/run/opa
+
+Restart=always
+RestartSec=5
+Restart=on-failure
+
+DynamicUser=yes
+ProtectSystem=full
+PrivateTmp=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/additional-scripts/opa/opa.service
+++ b/scripts/additional-scripts/opa/opa.service
@@ -12,7 +12,7 @@ WorkingDirectory=/run/opa
 
 Restart=always
 RestartSec=5
-Restart=on-failure
+Restart=on-abnormal
 
 DynamicUser=yes
 ProtectSystem=full


### PR DESCRIPTION
# TO TEST
* this AMI [ami-05080e4998b881ee0](https://us-east-2.console.aws.amazon.com/ec2/home?region=us-east-2#ImageDetails:imageId=ami-05080e4998b881ee0) is deployed. en ce2 instance can be spun up with it.
* assuming a good ssh setup, you can ssh into the new ec2 instance if you're on CAPE VPN. when in the machine, the following should show the OPA ascii logo: `curl localhost:8181/` and systemctl should show `opa.service` running and enabled