### PR TITLE
feat(jupyterhub): set `JUPYTERHUB_CRYPT_KEY`

### DIFF
--- a/scripts/additional-scripts/jupyterhub/01-install-jupyterhub.sh
+++ b/scripts/additional-scripts/jupyterhub/01-install-jupyterhub.sh
@@ -4,11 +4,18 @@ set -ex
 AMI_SCRIPTS=/tmp/additional-scripts/"${AMI_PREFIX}"
 JUPYTERHUB_PATH=/opt/jupyterhub
 
+sudo mkdir -p "${JUPYTERHUB_PATH}"
+
+sudo tee ${JUPYTERHUB_PATH}/env <<EOF
+JUPYTERHUB_CRYPT_KEY=$(openssl rand -hex 32)
+PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/jupyterhub/bin
+EOF
+
 #  add jupyterhub groups
 sudo groupadd --force jupyterhub-users
 
 # install http proxy
-sudo npm install -g configurable-http-proxy
+sudo npm install -g configurable-http-proxy@4
 
 # create jupyterhub environment
 sudo python3 -m venv "${JUPYTERHUB_PATH}"

--- a/scripts/additional-scripts/jupyterhub/jupyterhub.service
+++ b/scripts/additional-scripts/jupyterhub/jupyterhub.service
@@ -4,7 +4,8 @@ After=syslog.target network.target
 
 [Service]
 User=root
-Environment="PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/jupyterhub/bin"
+EnvironmentFile=/opt/jupyterhub/env
+PassEnvironment=JUPYTERHUB_CRYPT_KEY
 ExecStart=/opt/jupyterhub/bin/jupyterhub -f /opt/jupyterhub/etc/jupyterhub/jupyterhub_config.py
 
 [Install]


### PR DESCRIPTION
Properly setup `$JUPYTERHUB_CRYPT_KEY` to be able to enable persistent `auth_state` within JupyterHub