### PR TITLE
feat: add initial cape-frontend AMI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,6 @@ validate-jupyterhub: check-region init jupyterhub.pkrvars.hcl
 build-jupyterhub: check-region init validate release.auto.pkrvars.hcl jupyterhub.pkrvars.hcl
 	packer build -only="amazon-ebs.al2023" -var "region=${REGION}" --var-file="jupyterhub.pkrvars.hcl" .
 
-
 .PHONY: validate-opa
 validate-opa: check-region init opa.pkrvars.hcl
 	packer validate -var "region=${REGION}" --var-file="opa.pkrvars.hcl" .
@@ -56,3 +55,11 @@ validate-opa: check-region init opa.pkrvars.hcl
 .PHONY: build-opa
 build-opa: check-region init validate release.auto.pkrvars.hcl opa.pkrvars.hcl
 	packer build -only="amazon-ebs.al2023" -var "region=${REGION}" --var-file="opa.pkrvars.hcl" .
+
+.PHONY: validate-cape-frontend
+validate-cape-frontend: check-region init cape-frontend.pkrvars.hcl
+	packer validate -var "region=${REGION}" --var-file="cape-frontend.pkrvars.hcl" .
+
+.PHONY: build-cape-frontend
+build-cape-frontend: check-region init validate release.auto.pkrvars.hcl cape-frontend.pkrvars.hcl
+	packer build -only="amazon-ebs.al2023" -var "region=${REGION}" --var-file="cape-frontend.pkrvars.hcl" .

--- a/cape-frontend.pkrvars.hcl
+++ b/cape-frontend.pkrvars.hcl
@@ -1,0 +1,2 @@
+ami_name_prefix     = "cape-frontend"
+additional_packages = "git nodejs npm"

--- a/scripts/additional-scripts/cape-frontend/01-install-cape-frontend.sh
+++ b/scripts/additional-scripts/cape-frontend/01-install-cape-frontend.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -ex
+
+AMI_SCRIPTS=/tmp/additional-scripts/"${AMI_PREFIX}"
+CAPE_FRONTEND_PATH=/opt/cape-frontend
+
+sudo mkdir -p "${CAPE_FRONTEND_PATH}"
+
+# Clone CAPE Frontend repo
+sudo git clone --depth 1 https://github.com/cape-ph/cape-frontend.git ${CAPE_FRONTEND_PATH}/repo
+
+# Create base environment file
+sudo tee ${CAPE_FRONTEND_PATH}/env <<EOF
+NODE_ENV=production
+HOST=0.0.0.0
+EOF
+
+cd /opt/cape-frontend/repo
+
+# install dependencies
+sudo npm install --force
+
+# build web app
+sudo npm run build
+
+# copy cape-frontend service file
+sudo mkdir -p "${CAPE_FRONTEND_PATH}"/etc/systemd
+sudo cp "${AMI_SCRIPTS}"/cape-frontend.service "${CAPE_FRONTEND_PATH}"/etc/systemd/cape-frontend.service
+sudo ln -s "${CAPE_FRONTEND_PATH}"/etc/systemd/cape-frontend.service /etc/systemd/system/cape-frontend.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now cape-frontend.service

--- a/scripts/additional-scripts/cape-frontend/cape-frontend.service
+++ b/scripts/additional-scripts/cape-frontend/cape-frontend.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=CAPE Frontend
+After=syslog.target network.target
+
+[Service]
+User=root
+EnvironmentFile=/opt/cape-frontend/env
+WorkingDirectory=/opt/cape-frontend/repo
+ExecStart=node build
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This builds and deploys the CAPE frontend project as an AMI and sets up the file `/opt/cape-frontend/env` for storing and setting up environment variables. This should be set up on instantiation of the EC2 instance in the infrastructure for the app to run properly.