### PR TITLE
feat: add AMI for nextflow with kraken2 loaded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,14 @@ validate-nextflow: check-region init nextflow.pkrvars.hcl
 build-nextflow: check-region init validate release.auto.pkrvars.hcl nextflow.pkrvars.hcl
 	packer build -only="amazon-ebs.al2023" -var "region=${REGION}" --var-file="nextflow.pkrvars.hcl" .
 
+.PHONY: validate-nextflow-kraken2
+validate-nextflow-kraken2: check-region init nextflow-kraken2.pkrvars.hcl
+	packer validate -var "region=${REGION}" --var-file="nextflow-kraken2.pkrvars.hcl" .
+
+.PHONY: build-nextflow-kraken2
+build-nextflow-kraken2: check-region init validate release.auto.pkrvars.hcl nextflow-kraken2.pkrvars.hcl
+	packer build -only="amazon-ebs.al2023" -var "region=${REGION}" --var-file="nextflow-kraken2.pkrvars.hcl" .
+
 .PHONY: validate-jupyterhub
 validate-jupyterhub: check-region init jupyterhub.pkrvars.hcl
 	packer validate -var "region=${REGION}" --var-file="jupyterhub.pkrvars.hcl" .

--- a/nextflow-kraken2.pkrvars.hcl
+++ b/nextflow-kraken2.pkrvars.hcl
@@ -1,0 +1,3 @@
+ami_name_prefix      = "nextflow-kraken2"
+additional_packages  = "python3-pip wget jq java-21-amazon-corretto-devel g++ perl zlib-devel"
+block_device_size_gb = 100

--- a/scripts/additional-scripts/nextflow-kraken2/01-install-nextflow.sh
+++ b/scripts/additional-scripts/nextflow-kraken2/01-install-nextflow.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -ex
+
+# download nextflow and build it
+curl -s https://get.nextflow.io | bash
+# make the created binary executable
+chmod +x nextflow
+# move it into place
+sudo mv nextflow /usr/local/bin

--- a/scripts/additional-scripts/nextflow-kraken2/02-setup-kraken.sh
+++ b/scripts/additional-scripts/nextflow-kraken2/02-setup-kraken.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -ex
+
+# Install kraken2 from source code in GitHub
+mkdir kraken2
+cd kraken2
+wget https://github.com/DerrickWood/kraken2/archive/refs/tags/v2.1.6.zip
+unzip v2.1.6.zip
+rm -rf v2.1.6.zip
+./kraken2-2.1.6/install_kraken2.sh .
+sudo ln -s $(pwd)/kraken2-2.1.6/kraken2 /usr/local/bin
+sudo ln -s $(pwd)/kraken2-2.1.6/kraken2-build /usr/local/bin
+sudo ln -s $(pwd)/kraken2-2.1.6/kraken2-inspect /usr/local/bin
+
+# download pre-built standard kraken db
+wget -O db.tar.gz https://genome-idx.s3.amazonaws.com/kraken/k2_standard_20250714.tar.gz


### PR DESCRIPTION
This builds a modified version of the Nextflow AMI that has kraken2 installed along with a pre-built kraken2 database