### PR TITLE
bumped opa from 1.4.2->1.18.0

### DIFF
--- a/scripts/additional-scripts/opa/01-install-opa.sh
+++ b/scripts/additional-scripts/opa/01-install-opa.sh
@@ -3,7 +3,7 @@ set -ex
 
 AMI_SCRIPTS=/tmp/additional-scripts/"${AMI_PREFIX}"
 
-OPA_VERSION=v1.4.2
+OPA_VERSION=v1.18.0
 LOCAL_BIN=/usr/local/bin
 OPA_ETC_PATH=/etc/opa
 


### PR DESCRIPTION
# TO TEST

This has been built and deployed to test. AMI `ami-07b9e418d53f44854` is the new one and the OPA boxen in the infra have this AMI in use.